### PR TITLE
Redesigned Query API 🎉

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,19 @@ TODO: Replace me with a gif of the pkg in action.
 
 ## Table of Contents
 
-- [Quick Start](#quick-start)
-- [Markdown Files](#markdown-files)
-  - [MetaData section](#metadata-section)
-  - [Markdown section](#markdown-section)
-  - [Putting it all together](#putting-it-all-together)
-- [Testing](#testing)
-- [Examples](#examples)
-- [Maintainers](#maintainers)
-- [Contributing](#contributing)
-- [License](#license)
+* [Quick Start](#quick-start)
+* [Markdown Files](#markdown-files)
+  * [MetaData section](#metadata-section)
+  * [Markdown section](#markdown-section)
+  * [Putting it all together](#putting-it-all-together)
+* [Testing](#testing)
+* [Examples](#examples)
+* [Maintainers](#maintainers)
+* [Contributing](#contributing)
+* [License](#license)
 
 ## Quick Start
+
 **NOTE:** This package is still in development and is not yet published to the npm repository.
 
 ```sh
@@ -33,7 +34,9 @@ npm install --save https://github.com/okgrow/graphql-markdown
 # With Yarn
 yarn add https://github.com/okgrow/graphql-markdown
 ```
+
 Now lets follow the simple example below to get started quickly.
+
 ```js
 // server/index.js
 import hljs from 'highlight.js'; // Only install/used if you want to highlight code.
@@ -117,7 +120,6 @@ loadMarkdownIntoDb(options).then({
 })();
 ```
 
-
 ## Markdown files
 
 A markdown file contains two distinct sections, the MetaData section and the Markdown section.
@@ -144,6 +146,7 @@ groupId: homePage
 #### Markdown section
 
 The Markdown section is placed after the MetaData section and contains your markdown content. The markdown content will be converted into valid HTML when we process all markdown files and store them in memory.
+
 ```md
 # My First Markdown file
 
@@ -168,6 +171,96 @@ tags: [Happy, Learnings]
 Hello world! Thanks for dropping by to say hello.
 ```
 
+## Querying Your Data
+
+Graphql Markdown provides a few approaches to querying for your ContentItems. We also provide a way to `sort`, `limit`, and `skip` your results allows a basic (naive) form of pagination. 🍾
+
+* 💪 A powerful & all purpose query: Search by logical AND, OR conditions on any fields!!! 🎉
+
+```graphql
+ contentItems(filter: FilterFields!, pagination: Pagination): [ContentItem!]
+```
+
+* 🎁 Simplified helper queries: providing a clean & crisp syntax for common querying patterns. 🎊
+
+```graphql
+contentItemById(id: ID!): ContentItem
+contentItemsByIds(ids: [ID!]!, pagination: Pagination): [ContentItem!]
+contentItemsByGroupId(groupId: ID!, pagination: Pagination): [ContentItem!]
+```
+
+* 🎀 Organise the query results: Simple syntax to sort, skip, and limit your results. 🎈
+
+```graphql
+enum OrderBy {
+  ASCENDING
+  DESCENDING
+}
+
+# Sort results by a specific field and order in Ascending or Descending order.
+# e.g -> { sortBy: "date", orderBy: "DESCENDING" }
+input Sort {
+  sortBy: String! # Field to sort by. e.g -> "date"
+  orderBy: OrderBy! # ASCENDING or DESCENDING order. e.g -> "DESCENDING"
+}
+
+input Pagination {
+  sort: Sort # Sort and order elements by a specific field in a specific order.
+  skip: Int # Do not return the first x elements.
+  limit: Int # Limit the number of elements to return.
+}
+```
+
+Run the simple-example found in `examples/simple`, and copy/paste the below snippet into GraphiQL to see the response yourself!🔥
+
+```graphql
+{
+  # Simplified helper query to search for a single ContentItem.
+  # Returns a ContentItem, else null if not found.
+  contentItemById(id: "homePage") {
+    description
+  }
+
+  # Simplified helper query to search for ContentItems by ids.
+  # Returns a List of contentItems, else empty List if none found.
+  # Supports Pagination (sort, skip, limit).
+  contentItemsByIds(ids: ["graphqlIntro", "foo"]) {
+    id
+    tags
+  }
+
+  # Simplified helper query to search for ContentItems by groupId.
+  # Return a List of contentItems, else empty List if none found.
+  # Supports Pagination (sort, skip, limit).
+  contentItemsByGroupId(groupId: "simple-example") {
+    id
+    groupId
+    tags
+  }
+
+  # Full powered query to search for ContentItems by any field!!!
+  # Supports searching by logical AND, OR conditions on any fields.
+  # Return a List of contentItems, else empty List if none found.
+  # Supports Pagination (sort, skip, limit).
+  contentItems(
+    filter: { AND: { id: "homePage", groupId: "simple-example" } }
+    pagination: {
+      sort: { sortBy: "order", orderBy: DESCENDING }
+      skip: 0
+      limit: 0
+    }
+  ) {
+    id
+    groupId
+    type
+    description
+    date
+    tags
+    html
+  }
+}
+```
+
 ## Testing
 
 ```sh
@@ -182,14 +275,16 @@ npm run test
 ## Examples
 
 Check out the examples folder to see how it all works. Please note:
-- Node version 8+ is required.
-- You must run `npm install` on the main package first as the examples import the `/dist` files.
-- Examples contain detailed instructions & example queries to copy paste into Graphiql.
+
+* Node version 8+ is required.
+* You must run `npm install` on the main package first as the examples import the `/dist` files.
+* Examples contain detailed instructions & example queries to copy paste into Graphiql.
 
 ## Maintainers
 
 This is an open source package. We hope to deal with contributions in a timely manner, but that's not always the case. The main maintainers are:
 
+[@cfnelson](https://github.com/cfnelson)
 [@okgrow](https://github.com/okgrow)
 
 Feel free to ping if there are open issues or pull requests which are taking a while to be dealt with!
@@ -205,4 +300,5 @@ If you are interested in becoming a maintainer, get in touch with us by sending 
 Please note that all interactions in @okgrow's repos should follow our [Code of Conduct](https://github.com/okgrow/guides/blob/master/open-source/CODE_OF_CONDUCT.md).
 
 ## License
+
 Released under the [MIT license](https://github.com/okgrow/analytics/blob/master/License.md) © 2017 OK GROW!.

--- a/README.md
+++ b/README.md
@@ -218,24 +218,36 @@ Run the simple-example found in `examples/simple`, and copy/paste the below snip
   # Simplified helper query to search for a single ContentItem.
   # Returns a ContentItem, else null if not found.
   contentItemById(id: "homePage") {
+    html
     description
   }
 
   # Simplified helper query to search for ContentItems by ids.
   # Returns a List of contentItems, else empty List if none found.
   # Supports Pagination (sort, skip, limit).
-  contentItemsByIds(ids: ["graphqlIntro", "foo"]) {
+  contentItemsByIds(ids: ["graphqlIntro", "homePage"]) {
     id
     tags
+    order
   }
 
   # Simplified helper query to search for ContentItems by groupId.
   # Return a List of contentItems, else empty List if none found.
   # Supports Pagination (sort, skip, limit).
-  contentItemsByGroupId(groupId: "simple-example") {
+  contentItemsByGroupId(
+    groupId: "simple-example",
+    pagination: {
+      sort: {
+        sortBy: "order",
+        orderBy: DESCENDING
+      },
+      skip: 0,
+      limit: 0
+    })
+  {
     id
+    order
     groupId
-    tags
   }
 
   # Full powered query to search for ContentItems by any field!!!
@@ -243,20 +255,24 @@ Run the simple-example found in `examples/simple`, and copy/paste the below snip
   # Return a List of contentItems, else empty List if none found.
   # Supports Pagination (sort, skip, limit).
   contentItems(
-    filter: { AND: { id: "homePage", groupId: "simple-example" } }
+    filter: {
+      AND:{
+        order: 2,
+        groupId: "simple-example"
+      }
+    },
     pagination: {
-      sort: { sortBy: "order", orderBy: DESCENDING }
-      skip: 0
-      limit: 0
-    }
-  ) {
+      sort: {
+        sortBy: "order",
+        orderBy: ASCENDING
+      }
+    })
+  {
     id
-    groupId
     type
-    description
     date
-    tags
-    html
+    groupId
+    description  
   }
 }
 ```

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -12478,44 +12478,109 @@ var processContentItems = function processContentItems(items, contentRoot) {
   return { contentItems, contentItemGqlFields };
 };
 
-// Creates the TypeDefs for this package by creating a new TypeDefs AST containing
-// the Type Definitions inferred from the front-matter section of our .md files.
-// @returns {Object} - { graphqlMarkdownTypeDefs } - The packages TypeDefs
-var createGraphqlMarkdownTypeDefs = function createGraphqlMarkdownTypeDefs(_ref8) {
-  var contentItemGqlFields = _ref8.contentItemGqlFields,
-      contentItemTypeDefs = _ref8.contentItemTypeDefs;
+// TODO: Improve comments & variable names
+/** Creates a new body string, by inserting the fieldDefs in the correct location.
+ *  @param {string} body - Existing body value from a graphql files AST.
+ *  @param {string} typeDefName - Name of the type def to modify.
+ *  @param {string} newFieldDefsStr - field defs to add to existing type Def.
+ *  @returns {string} - A new body string containing the inserted fieldDefs
+ */
+var updateBodyStr = function updateBodyStr(_ref8) {
+  var body = _ref8.body,
+      typeDefName = _ref8.typeDefName,
+      fieldDefsStr = _ref8.fieldDefsStr;
 
-  // Find where our type ContentItem is located in the definitions array.
-  var contentItemIndex = contentItemTypeDefs.definitions.findIndex(function (item) {
-    return item.name.value === 'ContentItem';
+  // Indexes for the points where we inject our new string into.
+  var startSearchIndex = body.indexOf(`${typeDefName} {`);
+  var startInsertIndex = body.indexOf('}', startSearchIndex);
+
+  // Contents before and after our insertion points
+  var beforeStr = body.slice(0, startInsertIndex);
+  var afterStr = body.slice(startInsertIndex);
+
+  return `${beforeStr}${fieldDefsStr}${afterStr}`;
+};
+
+/** Find the location of the Type Defintion we wish to modify
+ *  in the GraphQL TypeDefs AST.
+ *  @param {Object} typeDefsAst - GraphQL TypeDefs AST to search.
+ *  @param {string} typeDefName - Name of the typeDef to search for
+ *  @returns {number} - Index for the TypeDefs location in the definitons array.
+ */
+var getTypeDefIndex = function getTypeDefIndex(_ref9) {
+  var typeDefsAst = _ref9.typeDefsAst,
+      typeDefName = _ref9.typeDefName;
+  return typeDefsAst.definitions.findIndex(function (item) {
+    return item.name.value === typeDefName;
+  });
+};
+
+/** Add new field definitions to an existing GraphQL TypeDefs AST.
+ *  NOTE: This approach can be improved & abstracted further.
+ *  Refactor to be DRY whilst accounting for perf.
+ *  @param {Object} originalTypeDefs - GraphQL TypeDefs AST to modify.
+ *  @param {Object} fieldDefsToAdd - Contains all the new fieldDefs to add.
+ *  @returns {Object} - GraphQL AST containing the fieldsDefs we wished to add.
+ */
+var createGraphqlMarkdownTypeDefs = function createGraphqlMarkdownTypeDefs(_ref10) {
+  var originalTypeDefs = _ref10.originalTypeDefs,
+      fieldDefsToAdd = _ref10.fieldDefsToAdd;
+
+  // Create a copy with no references to original.
+  // As we intend to mutate the TypeDefsAst directly.
+  var typeDefsAst = lodash_clonedeep(originalTypeDefs);
+
+  // Find the indexes for the TypeDefs we will modify.
+  var typeContentItemIndex = getTypeDefIndex({
+    typeDefsAst: originalTypeDefs,
+    typeDefName: 'ContentItem'
+  });
+  var inputTypeFieldsIndex = getTypeDefIndex({
+    typeDefsAst: originalTypeDefs,
+    typeDefName: 'Fields'
   });
 
   var newFieldDefsStr = '';
-  var typeDefsAst = lodash_clonedeep(contentItemTypeDefs);
 
-  Object.keys(contentItemGqlFields).forEach(function (field) {
-    var isID = field === 'id' || field === 'groupId';
-    if (!isID) {
-      // Add the new field def to our ContentItem type
-      typeDefsAst.definitions[contentItemIndex].fields.push(contentItemGqlFields[field].ast);
-      // Store the new field def to be added to our ContentItem type
-      newFieldDefsStr += `  ${field}: ${contentItemGqlFields[field].gqlType}\n`;
+  // Add the new Field Defs to the typeDefsAst
+  Object.keys(fieldDefsToAdd).forEach(function (field) {
+    var isProtectedField = field === 'id' || field === 'groupId' || field === 'html';
+
+    // Do not allow fields from .md front-matter to replace
+    // the existing AST for any of our reserved fields.
+    if (!isProtectedField) {
+      // Add the field def to our type ContentItem
+      typeDefsAst.definitions[typeContentItemIndex].fields.push(fieldDefsToAdd[field].ast);
+
+      // Add the field def to our type input Fields
+      typeDefsAst.definitions[inputTypeFieldsIndex].fields.push(fieldDefsToAdd[field].ast);
+
+      // Construct a string version of the fieldDefs we have added.
+      newFieldDefsStr += `  ${field}: ${fieldDefsToAdd[field].gqlType}\n`;
     }
   });
 
   // Modify the TypeDefs ASTs source body string to match the new fields we inserted.
-  var gqlStr = contentItemTypeDefs.loc.source.body;
-  // Indexes for where to split the source body in half
-  var startSearchIndex = gqlStr.indexOf('ContentItem {');
-  var startInsertIndex = gqlStr.indexOf('}', startSearchIndex);
-  var beforeStr = gqlStr.slice(0, startInsertIndex);
-  var afterStr = gqlStr.slice(startInsertIndex);
+  var gqlStr = originalTypeDefs.loc.source.body;
+
+  // Insert the field defs into type ContentItem
+  var tempBody = updateBodyStr({
+    body: gqlStr,
+    typeDefName: 'ContentItem',
+    fieldDefsStr: newFieldDefsStr
+  });
+
+  // Insert the field defs into input Fields
+  var newBody = updateBodyStr({
+    body: tempBody,
+    typeDefName: 'Fields',
+    fieldDefsStr: newFieldDefsStr
+  });
 
   // Replace the old source body with our own version which
   // contains the new fields defs taken from the .md front-matter.
-  typeDefsAst.loc.source.body = `${beforeStr}${newFieldDefsStr}${afterStr}`;
-
-  return { graphqlMarkdownTypeDefs: typeDefsAst };
+  typeDefsAst.loc.source.body = newBody;
+  return typeDefsAst;
 };
 
 /**
@@ -19166,8 +19231,8 @@ var Query = {
 
 var contentItemResolvers = { Query };
 
-var doc = { "kind": "Document", "definitions": [{ "kind": "EnumTypeDefinition", "name": { "kind": "Name", "value": "OrderBy" }, "directives": [], "values": [{ "kind": "EnumValueDefinition", "name": { "kind": "Name", "value": "ASCENDING" }, "directives": [] }, { "kind": "EnumValueDefinition", "name": { "kind": "Name", "value": "DESCENDING" }, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "Sort" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "sortBy" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "orderBy" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "OrderBy" } } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "Pagination" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "sort" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Sort" } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "skip" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Int" } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "limit" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Int" } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "FieldMatch" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "name" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "value" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "FieldMatcher" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "fields" }, "type": { "kind": "NonNullType", "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "FieldMatch" } } } } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "ContentItemsQuery" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "ids" }, "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "groupIds" }, "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "fieldMatcher" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "FieldMatcher" } }, "defaultValue": null, "directives": [] }] }, { "kind": "ObjectTypeDefinition", "name": { "kind": "Name", "value": "ContentItem" }, "interfaces": [], "directives": [], "fields": [{ "kind": "FieldDefinition", "name": { "kind": "Name", "value": "id" }, "arguments": [], "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "groupId" }, "arguments": [], "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "html" }, "arguments": [], "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } }, "directives": [] }] }, { "kind": "ObjectTypeDefinition", "name": { "kind": "Name", "value": "Query" }, "interfaces": [], "directives": [], "fields": [{ "kind": "FieldDefinition", "name": { "kind": "Name", "value": "contentItem" }, "arguments": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "id" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } }, "defaultValue": null, "directives": [] }], "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ContentItem" } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "contentItems" }, "arguments": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "query" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ContentItemsQuery" } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "pagination" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Pagination" } }, "defaultValue": null, "directives": [] }], "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ContentItem" } } } }, "directives": [] }] }], "loc": { "start": 0, "end": 890 } };
-doc.loc.source = { "body": "enum OrderBy {\n  ASCENDING\n  DESCENDING\n}\n\n# Sort and order results by a specific field and order.\n# e.g - { sortBy: \"date\", orderBy: \"DESCENDING\" }\ninput Sort {\n  # Field to sort by. e.g - \"date\"\n  sortBy: String!\n  # ASCENDING or DESCENDING order. e.g - \"DESCENDING\"\n  orderBy: OrderBy!\n}\n\ninput Pagination {\n  # Sort and order objects by a specific field in a specific order.\n  sort: Sort\n  # Do not return the first x objects.\n  skip: Int\n  # Limit the number of objects to return.\n  limit: Int\n}\n\ninput FieldMatch {\n  name: String!\n  value: String!\n}\n\ninput FieldMatcher {\n  fields: [FieldMatch!]!\n}\n\ninput ContentItemsQuery {\n  ids: [ID!]\n  groupIds: [ID!]\n  fieldMatcher: FieldMatcher\n}\n\ntype ContentItem {\n  id: ID!\n  groupId: ID!\n  html: String\n}\n\ntype Query {\n  contentItem(id: ID!): ContentItem\n  contentItems(query: ContentItemsQuery!, pagination: Pagination): [ContentItem!]\n}\n", "name": "GraphQL request", "locationOffset": { "line": 1, "column": 1 } };
+var doc = { "kind": "Document", "definitions": [{ "kind": "EnumTypeDefinition", "name": { "kind": "Name", "value": "OrderBy" }, "directives": [], "values": [{ "kind": "EnumValueDefinition", "name": { "kind": "Name", "value": "ASCENDING" }, "directives": [] }, { "kind": "EnumValueDefinition", "name": { "kind": "Name", "value": "DESCENDING" }, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "Sort" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "sortBy" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "orderBy" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "OrderBy" } } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "Pagination" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "sort" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Sort" } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "skip" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Int" } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "limit" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Int" } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "Fields" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "id" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "groupId" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "html" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } }, "defaultValue": null, "directives": [] }] }, { "kind": "ObjectTypeDefinition", "name": { "kind": "Name", "value": "ContentItem" }, "interfaces": [], "directives": [], "fields": [{ "kind": "FieldDefinition", "name": { "kind": "Name", "value": "id" }, "arguments": [], "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "groupId" }, "arguments": [], "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "html" }, "arguments": [], "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } }, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "FilterFields" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "AND" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Fields" } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "OR" }, "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Fields" } } } }, "defaultValue": null, "directives": [] }] }, { "kind": "ObjectTypeDefinition", "name": { "kind": "Name", "value": "Query" }, "interfaces": [], "directives": [], "fields": [{ "kind": "FieldDefinition", "name": { "kind": "Name", "value": "contentItemById" }, "arguments": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "id" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } }, "defaultValue": null, "directives": [] }], "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ContentItem" } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "contentItemsByIds" }, "arguments": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "ids" }, "type": { "kind": "NonNullType", "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "pagination" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Pagination" } }, "defaultValue": null, "directives": [] }], "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ContentItem" } } } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "contentItemsByGroupId" }, "arguments": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "groupId" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "pagination" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Pagination" } }, "defaultValue": null, "directives": [] }], "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ContentItem" } } } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "contentItems" }, "arguments": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "filter" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "FilterFields" } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "pagination" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Pagination" } }, "defaultValue": null, "directives": [] }], "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ContentItem" } } } }, "directives": [] }] }], "loc": { "start": 0, "end": 1568 } };
+doc.loc.source = { "body": "enum OrderBy {\n  ASCENDING\n  DESCENDING\n}\n\n# Sort and order results by a specific field and order.\n# e.g - { sortBy: \"date\", orderBy: \"DESCENDING\" }\ninput Sort {\n  # Field to sort by. e.g - \"date\"\n  sortBy: String!\n  # ASCENDING or DESCENDING order. e.g - \"DESCENDING\"\n  orderBy: OrderBy!\n}\n\ninput Pagination {\n  # Sort and order objects by a specific field in a specific order.\n  sort: Sort\n  # Do not return the first x objects.\n  skip: Int\n  # Limit the number of objects to return.\n  limit: Int\n}\n\ninput Fields {\n  id: ID\n  groupId: ID\n  html: String\n  # field defs generated from .md front-matter will be injected by pkg here.\n}\n\ntype ContentItem {\n  # Mandatory - a unique id must exist for every .md file.\n  id: ID!\n  # Mandatory - a non unique groupId must exist for every .md file. If you do not\n  # wish to manually set you can use the generateGroupIdByFolder option check pkg Readme.\n  groupId: ID!\n  # The html generated from parsing the .md contents.\n  html: String\n  # field defs generated from .md front-matter will be injected by pkg here.\n}\n\ninput FilterFields {\n  # Query ContentItems by any fields using logical AND condition.\n  AND: Fields\n  # Query ContentItems by any fields using logical OR condition.\n  OR: [Fields!]\n}\n\ntype Query {\n  contentItemById(id: ID!): ContentItem\n  contentItemsByIds(ids: [ID!]!, pagination: Pagination): [ContentItem!]\n  contentItemsByGroupId(groupId: ID!, pagination: Pagination): [ContentItem!]\n  # Query for contentItems by any field\n  contentItems(filter: FilterFields!, pagination: Pagination): [ContentItem!]\n}\n", "name": "GraphQL request", "locationOffset": { "line": 1, "column": 1 } };
 
 var _this = undefined;
 
@@ -19192,7 +19257,7 @@ var loadMarkdownIntoDb = function () {
         replaceContents = _ref.replaceContents,
         codeHighlighter = _ref.codeHighlighter;
 
-    var isFunction, defaultOptions, _ref3, contentItems, contentItemGqlFields, _createGraphqlMarkdow, graphqlMarkdownTypeDefs, itemsInserted;
+    var isFunction, defaultOptions, _ref3, contentItems, contentItemGqlFields, graphqlMarkdownTypeDefs, itemsInserted;
 
     return regenerator.wrap(function _callee$(_context) {
       while (1) {
@@ -19227,10 +19292,10 @@ var loadMarkdownIntoDb = function () {
 
 
             // Generate the packages TypeDefs to return to the pkg user
-            _createGraphqlMarkdow = createGraphqlMarkdownTypeDefs({
-              contentItemGqlFields,
-              contentItemTypeDefs: doc
-            }), graphqlMarkdownTypeDefs = _createGraphqlMarkdow.graphqlMarkdownTypeDefs;
+            graphqlMarkdownTypeDefs = createGraphqlMarkdownTypeDefs({
+              originalTypeDefs: doc,
+              fieldDefsToAdd: contentItemGqlFields
+            });
 
             // Insert all ContentItems into the in-memory nedb instance.
 

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -5865,43 +5865,7 @@ var objectWithoutProperties = function (obj, keys) {
 
 
 
-var slicedToArray = function () {
-  function sliceIterator(arr, i) {
-    var _arr = [];
-    var _n = true;
-    var _d = false;
-    var _e = undefined;
 
-    try {
-      for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
-        _arr.push(_s.value);
-
-        if (i && _arr.length === i) break;
-      }
-    } catch (err) {
-      _d = true;
-      _e = err;
-    } finally {
-      try {
-        if (!_n && _i["return"]) _i["return"]();
-      } finally {
-        if (_d) throw _e;
-      }
-    }
-
-    return _arr;
-  }
-
-  return function (arr, i) {
-    if (Array.isArray(arr)) {
-      return arr;
-    } else if (Symbol.iterator in Object(arr)) {
-      return sliceIterator(arr, i);
-    } else {
-      throw new TypeError("Invalid attempt to destructure non-iterable instance");
-    }
-  };
-}();
 
 
 
@@ -12556,28 +12520,6 @@ var getRelativeFilename = function getRelativeFilename(fullPathName) {
   return fullPathName.slice(fullPathName.lastIndexOf('/') + 1);
 };
 
-/**
- * Convert metaData from it's Object format to an Array of Objects.
- * NOTE: We are using es7 Object.entries.
- * @param {Object} metaData - Extra key/value pairs from a .md file. e.g - { foo: "bar" }
- * @returns {Array} metaData matching the gql schema format. e.g - [{ name: "foo", value: "bar" }, ...]
- */
-
-
-/**
- * Convert metaData from it's gql schema format to it's Object format
- * with "key": "value" pairs.
- * @param {Array} metaData - [{ name: "", value: "foo" }, ...]
- * @returns {Object} metaData formatted as an object with it's "key": "value" pairs.
- */
-var metaDataToObject = function metaDataToObject(metaData) {
-  return metaData.reduce(function (sum, _ref3) {
-    var name = _ref3.name,
-        value = _ref3.value;
-    return _extends({}, sum, { [name]: value });
-  }, {});
-};
-
 // TODO: Decide if we will keep the getGroupId function
 /**
  * Returns the groupId from the file's path.
@@ -12596,12 +12538,12 @@ var getGroupId = function getGroupId(assetDir) {
  * @param {Object} params
  * @returns {Object} A ContentItem matching the gql schema typeDef/
  */
-var mapContentItems = function mapContentItems(_ref4) {
-  var _id = _ref4._id,
-      markdown = _ref4.markdown,
-      assetDir = _ref4.assetDir,
-      images = _ref4.images,
-      fields = objectWithoutProperties(_ref4, ['_id', 'markdown', 'assetDir', 'images']);
+var mapContentItems = function mapContentItems(_ref) {
+  var _id = _ref._id,
+      markdown = _ref.markdown,
+      assetDir = _ref.assetDir,
+      images = _ref.images,
+      fields = objectWithoutProperties(_ref, ['_id', 'markdown', 'assetDir', 'images']);
   return fields;
 };
 
@@ -12613,27 +12555,6 @@ var convertOrderBy = function convertOrderBy(orderBy) {
 };
 
 /**
- * Determine if a query has mulitple arguments
- * @param {Object} args - object containing all args provided by the client.
- * @returns {boolean}
- */
-// prettier-ignore
-var isMultiArgsQuery = function isMultiArgsQuery(args) {
-  var count = Object.entries(args).reduce(function (sum, _ref5) {
-    var _ref6 = slicedToArray(_ref5, 2),
-        key = _ref6[0],
-        value = _ref6[1];
-
-    // eslint-disable-line
-    if (value && value.length > 0) {
-      return sum + 1;
-    }
-    return sum;
-  }, 0);
-  return count > 1;
-};
-
-/**
  * Replace all relative image paths in our html e.g - <img src="path" ...> with a path that we prescribe like a cdn. e.g - "cdn.com/foo.png"
  * @param {Object} param
  * @param {string[]} obj.images - e.g - [".../foo.jpg", ...]
@@ -12641,10 +12562,10 @@ var isMultiArgsQuery = function isMultiArgsQuery(args) {
  * @param {string} obj.html - html that we will process
  * @returns {string} valid html with the <img src="" ...> correctly updated.
  */
-var replaceHtmlImageSrc = function replaceHtmlImageSrc(_ref7) {
-  var images = _ref7.images,
-      imageMap = _ref7.imageMap,
-      html = _ref7.html;
+var replaceHtmlImageSrc = function replaceHtmlImageSrc(_ref2) {
+  var images = _ref2.images,
+      imageMap = _ref2.imageMap,
+      html = _ref2.html;
   return images.reduce(function (sum, imageFileName) {
     var imageName = getRelativeFilename(imageFileName);
     return sum.replace(imageName, imageMap[imageFileName]);
@@ -12665,7 +12586,7 @@ var _this$3 = undefined;
  * Expected format is "(ext|ext|ext)" e.g - "(png|svg|jpg)"
  * @param {function} param.replaceContents - Manipulate the contents of the .md file before processing.
  * @returns {Object} Created from the contents of the .md file that has been processed.
-*/
+ */
 var getMarkdownObject = function () {
   var _ref2 = asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee(_ref) {
     var filename = _ref.filename,
@@ -12688,6 +12609,7 @@ var getMarkdownObject = function () {
 
             fileContents = replaceContents ? replaceContents({ contentRoot, rawContents }) : rawContents;
 
+            // TODO: Abstract the below matter processing into its own function
             // WARNING: The 4 variables below are mutated directly by gqlTypeListener()
 
             currKey = ''; // eslint-disable-line
@@ -12720,8 +12642,10 @@ var getMarkdownObject = function () {
             html = _context.sent;
             images = getListOfRelativeImageFiles(contentRoot, assetDir, imageFormats);
 
-            // TODO: Deprecate this in future ?
-            // If we deprecate then we must state every .md file must provide a groupId!
+            // TODO: Setup logic for if generateGroupIdByFolder is true
+            // When true, we will enable defaultGroupId to be inferred from the folder the
+            // .md file is currently located within.
+            // When not turned on every .md file must set a groupId!
 
             defaultGroupId = getGroupId(assetDir);
             newHtml = replaceHtmlImageSrc({ images, imageMap, html });
@@ -12768,7 +12692,8 @@ var loadContentItems = function () {
         replaceContents = _ref.replaceContents,
         _ref$debugMode = _ref.debugMode,
         debugMode = _ref$debugMode === undefined ? false : _ref$debugMode,
-        codeHighlighter = _ref.codeHighlighter;
+        codeHighlighter = _ref.codeHighlighter,
+        _ref$generateGroupIdB = _ref.generateGroupIdByFolder;
     var isFunction, imageMap, mdFiles, contentItems;
     return regenerator.wrap(function _callee2$(_context2) {
       while (1) {
@@ -18863,7 +18788,7 @@ var _this$5 = undefined;
  * @param {string} id - The id of the ContentItem
  * @returns {Object|null} returns the ContentItem or null on error.
  */
-var getContentItem = function () {
+var findContentItemById = function () {
   var _ref = asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee(id) {
     var contentItem;
     return regenerator.wrap(function _callee$(_context) {
@@ -18904,30 +18829,19 @@ var getContentItem = function () {
     }, _callee, _this$5, [[1, 8]]);
   }));
 
-  return function getContentItem(_x) {
+  return function findContentItemById(_x) {
     return _ref.apply(this, arguments);
   };
 }();
 
-/**
- * Creates an object that maps the local fullPath of an image to it's desired path. e.g - { fullPathName: "cdn.com/foo.png", ... }
- * @param {Object} param
- * @param {string[]} param.ids - ContentItem's ids
- * @param {string[]} param.groupIds - ContentItem's groupIds
- * @param {Object} param.fieldMatcher - Refer to FieldMatcher in `src/graphql/typeDefs.graphql`
- * @param {Object} param.pagination - Refer to Pagination in `src/graphql/typeDefs.graphql`
- * @returns {Object[]} returns an array of ContentItems.
- */
-var getContentItems = function () {
+// *********************** TODO ********************
+// TODO: Refactor and abstract all three functions try/catch block code into
+// a single function that will query the nedb for us.
+// e.g queryDB({ query, sort, skip, limit, errorMsg });
+var findContentItemsByIds = function () {
   var _ref3 = asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee2(_ref2) {
     var _ref2$ids = _ref2.ids,
         ids = _ref2$ids === undefined ? [] : _ref2$ids,
-        _ref2$groupIds = _ref2.groupIds,
-        groupIds = _ref2$groupIds === undefined ? [] : _ref2$groupIds,
-        _ref2$fieldMatcher = _ref2.fieldMatcher;
-    _ref2$fieldMatcher = _ref2$fieldMatcher === undefined ? {} : _ref2$fieldMatcher;
-    var _ref2$fieldMatcher$fi = _ref2$fieldMatcher.fields,
-        fields = _ref2$fieldMatcher$fi === undefined ? [] : _ref2$fieldMatcher$fi,
         _ref2$pagination = _ref2.pagination;
     _ref2$pagination = _ref2$pagination === undefined ? {} : _ref2$pagination;
     var _ref2$pagination$sort = _ref2$pagination.sort,
@@ -18936,33 +18850,23 @@ var getContentItems = function () {
         skip = _ref2$pagination$skip === undefined ? 0 : _ref2$pagination$skip,
         _ref2$pagination$limi = _ref2$pagination.limit,
         limit = _ref2$pagination$limi === undefined ? 0 : _ref2$pagination$limi;
-    var idsQuery, groupIdQuery, fieldsQuery, multiArgsQuery, singleArgQuery, query, sortOptions, contentItems;
+    var query, sortOptions, contentItems;
     return regenerator.wrap(function _callee2$(_context2) {
       while (1) {
         switch (_context2.prev = _context2.next) {
           case 0:
-            if (!(!groupIds.length && !ids.length && !fields.length)) {
+            if (ids.length) {
               _context2.next = 2;
               break;
             }
 
-            throw new Error('[getContentItems]: Query expects at least one param, either ids, groupIds, or fieldMatcher.');
+            throw new Error('[findContentItemsByIds]: You must provide at least one id.');
 
           case 2:
-            if (!(groupIds.length || ids.length || fields.length)) {
-              _context2.next = 20;
-              break;
-            }
-
-            _context2.prev = 3;
-            idsQuery = { id: { $in: ids } };
-            groupIdQuery = { groupId: { $in: groupIds } };
-            fieldsQuery = metaDataToObject(fields);
-            multiArgsQuery = { $or: [idsQuery, groupIdQuery, fieldsQuery] };
-            singleArgQuery = _extends({}, ids.length ? idsQuery : null, groupIds.length ? groupIdQuery : null, fields.length ? fieldsQuery : null);
-            query = isMultiArgsQuery({ ids, groupIds, fields }) ? multiArgsQuery : singleArgQuery;
+            _context2.prev = 2;
+            query = { id: { $in: ids } };
             sortOptions = sort ? { [sort.sortBy]: convertOrderBy(sort.orderBy) } : null;
-            _context2.next = 13;
+            _context2.next = 7;
             return find({
               db: dataStore,
               query,
@@ -18972,43 +18876,195 @@ var getContentItems = function () {
               mapFunc: mapContentItems
             });
 
-          case 13:
+          case 7:
             contentItems = _context2.sent;
             return _context2.abrupt('return', contentItems);
 
-          case 17:
-            _context2.prev = 17;
-            _context2.t0 = _context2['catch'](3);
+          case 11:
+            _context2.prev = 11;
+            _context2.t0 = _context2['catch'](2);
 
-            console.error('[getContentItems]', _context2.t0); // eslint-disable-line no-console
+            // TODO: Should we throw or only log?
+            console.error('[getContentItemsByIds] -> ', _context2.t0); // eslint-disable-line no-console
 
-          case 20:
+          case 14:
             return _context2.abrupt('return', []);
 
-          case 21:
+          case 15:
           case 'end':
             return _context2.stop();
         }
       }
-    }, _callee2, _this$5, [[3, 17]]);
+    }, _callee2, _this$5, [[2, 11]]);
   }));
 
-  return function getContentItems(_x2) {
+  return function findContentItemsByIds(_x2) {
     return _ref3.apply(this, arguments);
+  };
+}();
+
+var findContentItemsByGroupId = function () {
+  var _ref5 = asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee3(_ref4) {
+    var groupId = _ref4.groupId,
+        _ref4$pagination = _ref4.pagination;
+    _ref4$pagination = _ref4$pagination === undefined ? {} : _ref4$pagination;
+    var _ref4$pagination$sort = _ref4$pagination.sort,
+        sort = _ref4$pagination$sort === undefined ? null : _ref4$pagination$sort,
+        _ref4$pagination$skip = _ref4$pagination.skip,
+        skip = _ref4$pagination$skip === undefined ? 0 : _ref4$pagination$skip,
+        _ref4$pagination$limi = _ref4$pagination.limit,
+        limit = _ref4$pagination$limi === undefined ? 0 : _ref4$pagination$limi;
+    var query, sortOptions, contentItems;
+    return regenerator.wrap(function _callee3$(_context3) {
+      while (1) {
+        switch (_context3.prev = _context3.next) {
+          case 0:
+            if (groupId) {
+              _context3.next = 2;
+              break;
+            }
+
+            throw new Error('[findByGroupId]: You must provide a groupId.');
+
+          case 2:
+            _context3.prev = 2;
+            query = { groupId };
+            sortOptions = sort ? { [sort.sortBy]: convertOrderBy(sort.orderBy) } : null;
+            _context3.next = 7;
+            return find({
+              db: dataStore,
+              query,
+              sortOptions,
+              skip,
+              limit,
+              mapFunc: mapContentItems
+            });
+
+          case 7:
+            contentItems = _context3.sent;
+            return _context3.abrupt('return', contentItems);
+
+          case 11:
+            _context3.prev = 11;
+            _context3.t0 = _context3['catch'](2);
+
+            // TODO: Should we throw or only log?
+            console.error('[getContentItemsByGroupId] -> ', _context3.t0); // eslint-disable-line no-console
+
+          case 14:
+            return _context3.abrupt('return', []);
+
+          case 15:
+          case 'end':
+            return _context3.stop();
+        }
+      }
+    }, _callee3, _this$5, [[2, 11]]);
+  }));
+
+  return function findContentItemsByGroupId(_x3) {
+    return _ref5.apply(this, arguments);
+  };
+}();
+
+// contentItems(filter: FilterFields!, pagination: Pagination): [ContentItem!]
+/**
+ *
+ * @param {Object} param
+ * @param {string[]} param.ids - ContentItem's ids
+ * @param {string[]} param.groupIds - ContentItem's groupIds
+ * @param {Object} param.fieldMatcher - Refer to FieldMatcher in `src/graphql/typeDefs.graphql`
+ * @param {Object} param.pagination - Refer to Pagination in `src/graphql/typeDefs.graphql`
+ * @returns {Object[]} returns an array of ContentItems.
+ */
+// getContentItems(ids: [foo, boo])
+// getContentItemsByField(fields: { title: "Hello World" });
+
+var findContentItemsByFilter = function () {
+  var _ref7 = asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee4(_ref6) {
+    var _ref6$filter = _ref6.filter;
+    _ref6$filter = _ref6$filter === undefined ? {} : _ref6$filter;
+    var _ref6$filter$AND = _ref6$filter.AND,
+        AND = _ref6$filter$AND === undefined ? {} : _ref6$filter$AND,
+        _ref6$filter$OR = _ref6$filter.OR,
+        OR = _ref6$filter$OR === undefined ? [] : _ref6$filter$OR,
+        _ref6$pagination = _ref6.pagination;
+    _ref6$pagination = _ref6$pagination === undefined ? {} : _ref6$pagination;
+    var _ref6$pagination$sort = _ref6$pagination.sort,
+        sort = _ref6$pagination$sort === undefined ? null : _ref6$pagination$sort,
+        _ref6$pagination$skip = _ref6$pagination.skip,
+        skip = _ref6$pagination$skip === undefined ? 0 : _ref6$pagination$skip,
+        _ref6$pagination$limi = _ref6$pagination.limit,
+        limit = _ref6$pagination$limi === undefined ? 0 : _ref6$pagination$limi;
+    var isAndEmpty, query, sortOptions, contentItems;
+    return regenerator.wrap(function _callee4$(_context4) {
+      while (1) {
+        switch (_context4.prev = _context4.next) {
+          case 0:
+            // NOTE: Currently do no support querying with AND + OR
+            // TODO: Throw error if try to filter with AND & OR
+            isAndEmpty = !Object.keys(AND).length;
+
+            // Only allowed to find ContentItems if fields have been provided
+
+            if (!(!OR.length && isAndEmpty)) {
+              _context4.next = 3;
+              break;
+            }
+
+            throw new Error('[findContentItemsByFilter]: You must provide at least one field to filter on.');
+
+          case 3:
+            _context4.prev = 3;
+            query = !isAndEmpty ? AND : { $or: OR };
+            sortOptions = sort ? { [sort.sortBy]: convertOrderBy(sort.orderBy) } : null;
+            _context4.next = 8;
+            return find({
+              db: dataStore,
+              query,
+              sortOptions,
+              skip,
+              limit,
+              mapFunc: mapContentItems
+            });
+
+          case 8:
+            contentItems = _context4.sent;
+            return _context4.abrupt('return', contentItems);
+
+          case 12:
+            _context4.prev = 12;
+            _context4.t0 = _context4['catch'](3);
+
+            console.error('[getContentItems] -> ', _context4.t0); // eslint-disable-line no-console
+
+          case 15:
+            return _context4.abrupt('return', []);
+
+          case 16:
+          case 'end':
+            return _context4.stop();
+        }
+      }
+    }, _callee4, _this$5, [[3, 12]]);
+  }));
+
+  return function findContentItemsByFilter(_x4) {
+    return _ref7.apply(this, arguments);
   };
 }();
 
 var _this$4 = undefined;
 
 var Query = {
-  contentItem: function () {
+  contentItemById: function () {
     var _ref2 = asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee(root, _ref /* , context */) {
       var id = _ref.id;
       return regenerator.wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
             case 0:
-              return _context.abrupt('return', getContentItem(id));
+              return _context.abrupt('return', findContentItemById(id));
 
             case 1:
             case 'end':
@@ -19018,21 +19074,22 @@ var Query = {
       }, _callee, _this$4);
     }));
 
-    function contentItem(_x, _x2) {
+    function contentItemById(_x, _x2) {
       return _ref2.apply(this, arguments);
     }
 
-    return contentItem;
+    return contentItemById;
   }(),
-  contentItems: function () {
+
+  contentItemsByIds: function () {
     var _ref4 = asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee2(root, _ref3 /* , context */) {
-      var query = _ref3.query,
+      var ids = _ref3.ids,
           pagination = _ref3.pagination;
       return regenerator.wrap(function _callee2$(_context2) {
         while (1) {
           switch (_context2.prev = _context2.next) {
             case 0:
-              return _context2.abrupt('return', getContentItems(_extends({}, query, { pagination })));
+              return _context2.abrupt('return', findContentItemsByIds({ ids, pagination }));
 
             case 1:
             case 'end':
@@ -19042,8 +19099,58 @@ var Query = {
       }, _callee2, _this$4);
     }));
 
-    function contentItems(_x3, _x4) {
+    function contentItemsByIds(_x3, _x4) {
       return _ref4.apply(this, arguments);
+    }
+
+    return contentItemsByIds;
+  }(),
+
+  contentItemsByGroupId: function () {
+    var _ref6 = asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee3(root, _ref5 /* , ctx */) {
+      var groupId = _ref5.groupId,
+          pagination = _ref5.pagination;
+      return regenerator.wrap(function _callee3$(_context3) {
+        while (1) {
+          switch (_context3.prev = _context3.next) {
+            case 0:
+              return _context3.abrupt('return', findContentItemsByGroupId({ groupId, pagination }));
+
+            case 1:
+            case 'end':
+              return _context3.stop();
+          }
+        }
+      }, _callee3, _this$4);
+    }));
+
+    function contentItemsByGroupId(_x5, _x6) {
+      return _ref6.apply(this, arguments);
+    }
+
+    return contentItemsByGroupId;
+  }(),
+
+  contentItems: function () {
+    var _ref8 = asyncToGenerator( /*#__PURE__*/regenerator.mark(function _callee4(root, _ref7 /* , context */) {
+      var filter = _ref7.filter,
+          pagination = _ref7.pagination;
+      return regenerator.wrap(function _callee4$(_context4) {
+        while (1) {
+          switch (_context4.prev = _context4.next) {
+            case 0:
+              return _context4.abrupt('return', findContentItemsByFilter({ filter, pagination }));
+
+            case 1:
+            case 'end':
+              return _context4.stop();
+          }
+        }
+      }, _callee4, _this$4);
+    }));
+
+    function contentItems(_x7, _x8) {
+      return _ref8.apply(this, arguments);
     }
 
     return contentItems;
@@ -19052,8 +19159,8 @@ var Query = {
 
 var contentItemResolvers = { Query };
 
-var doc = { "kind": "Document", "definitions": [{ "kind": "EnumTypeDefinition", "name": { "kind": "Name", "value": "OrderBy" }, "directives": [], "values": [{ "kind": "EnumValueDefinition", "name": { "kind": "Name", "value": "ASCENDING" }, "directives": [] }, { "kind": "EnumValueDefinition", "name": { "kind": "Name", "value": "DESCENDING" }, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "Sort" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "sortBy" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "orderBy" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "OrderBy" } } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "Pagination" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "sort" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Sort" } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "skip" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Int" } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "limit" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Int" } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "FieldMatch" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "name" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "value" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "FieldMatcher" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "fields" }, "type": { "kind": "NonNullType", "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "FieldMatch" } } } } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "ContentItemsQuery" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "ids" }, "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "groupIds" }, "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "fieldMatcher" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "FieldMatcher" } }, "defaultValue": null, "directives": [] }] }, { "kind": "ObjectTypeDefinition", "name": { "kind": "Name", "value": "MetaDataField" }, "interfaces": [], "directives": [], "fields": [{ "kind": "FieldDefinition", "name": { "kind": "Name", "value": "name" }, "arguments": [], "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "value" }, "arguments": [], "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } } }, "directives": [] }] }, { "kind": "ObjectTypeDefinition", "name": { "kind": "Name", "value": "ContentItem" }, "interfaces": [], "directives": [], "fields": [{ "kind": "FieldDefinition", "name": { "kind": "Name", "value": "id" }, "arguments": [], "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "groupId" }, "arguments": [], "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "html" }, "arguments": [], "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } }, "directives": [] }] }, { "kind": "ObjectTypeDefinition", "name": { "kind": "Name", "value": "Query" }, "interfaces": [], "directives": [], "fields": [{ "kind": "FieldDefinition", "name": { "kind": "Name", "value": "contentItem" }, "arguments": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "id" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } }, "defaultValue": null, "directives": [] }], "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ContentItem" } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "contentItems" }, "arguments": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "query" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ContentItemsQuery" } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "pagination" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Pagination" } }, "defaultValue": null, "directives": [] }], "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ContentItem" } } } }, "directives": [] }] }], "loc": { "start": 0, "end": 947 } };
-doc.loc.source = { "body": "enum OrderBy {\n  ASCENDING\n  DESCENDING\n}\n\n# Sort and order results by a specific field and order.\n# e.g - { sortBy: \"date\", orderBy: \"DESCENDING\" }\ninput Sort {\n  # Field to sort by. e.g - \"date\"\n  sortBy: String!\n  # ASCENDING or DESCENDING order. e.g - \"DESCENDING\"\n  orderBy: OrderBy!\n}\n\ninput Pagination {\n  # Sort and order objects by a specific field in a specific order.\n  sort: Sort\n  # Do not return the first x objects.\n  skip: Int\n  # Limit the number of objects to return.\n  limit: Int\n}\n\ninput FieldMatch {\n  name: String!\n  value: String!\n}\n\ninput FieldMatcher {\n  fields: [FieldMatch!]!\n}\n\ninput ContentItemsQuery {\n  ids: [ID!]\n  groupIds: [ID!]\n  fieldMatcher: FieldMatcher\n}\n\ntype MetaDataField {\n  name: String!\n  value: String!\n}\n\ntype ContentItem {\n  id: ID!\n  groupId: ID!\n  html: String\n}\n\ntype Query {\n  contentItem(id: ID!): ContentItem\n  contentItems(query: ContentItemsQuery!, pagination: Pagination): [ContentItem!]\n}\n", "name": "GraphQL request", "locationOffset": { "line": 1, "column": 1 } };
+var doc = { "kind": "Document", "definitions": [{ "kind": "EnumTypeDefinition", "name": { "kind": "Name", "value": "OrderBy" }, "directives": [], "values": [{ "kind": "EnumValueDefinition", "name": { "kind": "Name", "value": "ASCENDING" }, "directives": [] }, { "kind": "EnumValueDefinition", "name": { "kind": "Name", "value": "DESCENDING" }, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "Sort" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "sortBy" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "orderBy" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "OrderBy" } } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "Pagination" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "sort" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Sort" } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "skip" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Int" } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "limit" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Int" } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "FieldMatch" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "name" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "value" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "FieldMatcher" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "fields" }, "type": { "kind": "NonNullType", "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "FieldMatch" } } } } }, "defaultValue": null, "directives": [] }] }, { "kind": "InputObjectTypeDefinition", "name": { "kind": "Name", "value": "ContentItemsQuery" }, "directives": [], "fields": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "ids" }, "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "groupIds" }, "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "fieldMatcher" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "FieldMatcher" } }, "defaultValue": null, "directives": [] }] }, { "kind": "ObjectTypeDefinition", "name": { "kind": "Name", "value": "ContentItem" }, "interfaces": [], "directives": [], "fields": [{ "kind": "FieldDefinition", "name": { "kind": "Name", "value": "id" }, "arguments": [], "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "groupId" }, "arguments": [], "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "html" }, "arguments": [], "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "String" } }, "directives": [] }] }, { "kind": "ObjectTypeDefinition", "name": { "kind": "Name", "value": "Query" }, "interfaces": [], "directives": [], "fields": [{ "kind": "FieldDefinition", "name": { "kind": "Name", "value": "contentItem" }, "arguments": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "id" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ID" } } }, "defaultValue": null, "directives": [] }], "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ContentItem" } }, "directives": [] }, { "kind": "FieldDefinition", "name": { "kind": "Name", "value": "contentItems" }, "arguments": [{ "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "query" }, "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ContentItemsQuery" } } }, "defaultValue": null, "directives": [] }, { "kind": "InputValueDefinition", "name": { "kind": "Name", "value": "pagination" }, "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "Pagination" } }, "defaultValue": null, "directives": [] }], "type": { "kind": "ListType", "type": { "kind": "NonNullType", "type": { "kind": "NamedType", "name": { "kind": "Name", "value": "ContentItem" } } } }, "directives": [] }] }], "loc": { "start": 0, "end": 890 } };
+doc.loc.source = { "body": "enum OrderBy {\n  ASCENDING\n  DESCENDING\n}\n\n# Sort and order results by a specific field and order.\n# e.g - { sortBy: \"date\", orderBy: \"DESCENDING\" }\ninput Sort {\n  # Field to sort by. e.g - \"date\"\n  sortBy: String!\n  # ASCENDING or DESCENDING order. e.g - \"DESCENDING\"\n  orderBy: OrderBy!\n}\n\ninput Pagination {\n  # Sort and order objects by a specific field in a specific order.\n  sort: Sort\n  # Do not return the first x objects.\n  skip: Int\n  # Limit the number of objects to return.\n  limit: Int\n}\n\ninput FieldMatch {\n  name: String!\n  value: String!\n}\n\ninput FieldMatcher {\n  fields: [FieldMatch!]!\n}\n\ninput ContentItemsQuery {\n  ids: [ID!]\n  groupIds: [ID!]\n  fieldMatcher: FieldMatcher\n}\n\ntype ContentItem {\n  id: ID!\n  groupId: ID!\n  html: String\n}\n\ntype Query {\n  contentItem(id: ID!): ContentItem\n  contentItems(query: ContentItemsQuery!, pagination: Pagination): [ContentItem!]\n}\n", "name": "GraphQL request", "locationOffset": { "line": 1, "column": 1 } };
 
 var _this = undefined;
 

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -1,4 +1,4 @@
-# Simple Graphiql Example
+# Simple GraphiQL Example
 
 ## Requirements
 
@@ -16,62 +16,67 @@
 
 Below are some example queries demonstrating the packages capabilities. Give them a try in GraphiQL!
 
-### contentItem
+Any query that returns a List also supports a basic form of pagination via the ability to `sort`, `skip`, and `limit` the results returned from a query.
 
-```
+#### Query by id(s)
+
+```graphql
 {
-  contentItem(id: "graphqlIntro") {
+  # Simplified helper query to search for a single ContentItem.
+  # Returns a ContentItem, else null if not found.
+  contentItemById(id: "graphqlIntro") {
     id
     groupId
     html
     title
     tags
   }
-}
-```
 
-### contentItems query
-
-The `contentItems` query allows you to query by `ids`, `groupIds`, or `fieldMatcher`.
-
-- `ids` will match against the `id` in your `.md` file. Every `.md` file must have an `id`.
-- `groupIds` will match against the `groupId` in your `.md` file. Every `.md` file must have an `groupId`.
-- `fieldMatcher` will match against any specific field that you have set in your `.md` file.
-
-The `contentItems` query also supports a basic form of pagination via the ability to `sort`, `skip`, and `limit` the results returned from a query.
-
-#### Query by ids
-
-```
-{
-  contentItems(query: { ids: ["graphqlIntro", "homePage"] }) {
+  # Simplified helper query to search for ContentItems by ids.
+  # Returns a List of contentItems, else empty List if none found.
+  # Supports Pagination (sort, skip, limit).
+  contentItemsByIds(ids: ["graphqlIntro", "homePage"] ) {
     id
     groupId
   }
 }
 ```
 
-#### Query by groupIds
+#### Query by groupId
 
-```
+```graphql
 {
-  contentItems(query: { groupIds: ["simple-example"] }) {
+  # Simplified helper query to search for ContentItems by groupId.
+  # Return a List of contentItems, else empty List if none found.
+  # Supports Pagination (sort, skip, limit).
+  contentItemsByGroupId(groupId: "simple-example") {
     id
     groupId
   }
 }
 ```
 
-#### Query by fieldMatcher.
+#### Query by any field!
 
-```
+The `contentItems` query allows you to query on any field with a `filter` which uses the logical `AND`, `OR` conditions.
+
+```graphql
 {
+  # Full powered query to search for ContentItems by any field!!!
+  # Supports searching by logical AND, OR conditions on any fields.
+  # Return a List of contentItems, else empty List if none found.
+  # Supports Pagination (sort, skip, limit).
   contentItems(
-    query: { fieldMatcher: { fields: [{ name: "type", value: "page" }] } }
-  ){
+    filter: {
+      OR: [
+        { order: 2 },
+        { id: "graphqlIntro" }
+      ]
+    })
+  {
     id
+    order
     groupId
-    type
   }
 }
 ```
@@ -83,13 +88,17 @@ Try changing the below example and see what happens. Here are a few hints:
 - Set `skip` to 1 and `limit` to 0.
 - Set `skip` to 0 and `limit` to 1.
 - Swap `DESCENDING` with `ASCENDING`.
-- Replace `groupIds` with `ids: ["graphqlIntro", "homePage"]`
+- Replace `AND: { groupId: "simple-example" }` with `OR: [{ order: 2 }, { order: 1 }]`.
 - Remove `skip` and `limit` all together.
 
-```
+```graphql
 {
   contentItems(
-    query: { groupIds: ["simple-example"] },
+    filter: {
+      AND: {
+        groupId: "simple-example"
+      }
+    },
     pagination: {
       sort: {
         sortBy: "order",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,7 @@
   "description": "Write markdown, serve as html, query via GraphQL.🔥",
   "author": "OK GROW! <hello@okgrow.com> (https://www.okgrow.com)",
   "homepage": "https://github.com/okgrow/guides",
-  "keywords": [
-    "graphql",
-    "markdown",
-    "html"
-  ],
+  "keywords": ["graphql", "markdown", "html"],
   "repository": {
     "type": "git",
     "url": "https://github.com/okgrow/guides.git"
@@ -73,7 +69,5 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-watch": "^4.3.1"
   },
-  "files": [
-    "dist"
-  ]
+  "files": ["dist"]
 }

--- a/src/graphql/__mocks__/mockDbData.js
+++ b/src/graphql/__mocks__/mockDbData.js
@@ -3,7 +3,7 @@ export const CONTENT_ITEM_1 = {
   id: 'home_section',
   groupId: 'contentItems_test',
   html:
-    '<h1 id="welcome-to-this-super-example-">Welcome to this super example!</h1>\n',
+    '<h1 id="welcome-to-this-super-example-">Welcome to this super example!🎉🎉🎉</h1>\n',
   test: 'I am a ContentItem!',
   order: 1,
   temperature: 20.8,
@@ -34,7 +34,7 @@ export const EXPECTED_RESULT_1 = {
   id: 'home_section',
   groupId: 'contentItems_test',
   html:
-    '<h1 id="welcome-to-this-super-example-">Welcome to this super example!</h1>\n',
+    '<h1 id="welcome-to-this-super-example-">Welcome to this super example!🎉🎉🎉</h1>\n',
   test: 'I am a ContentItem!',
   order: 1,
   temperature: 20.8,
@@ -51,7 +51,6 @@ export const EXPECTED_RESULT_2 = {
 };
 
 export const EXPECTED_RESULT_3 = {
-  _id: 'contentItem_test_3',
   id: 'fire_man',
   groupId: 'fireman_test',
   html: '<p>🚒🔥🔥🔥🚒🔥🔥🔥🚒</p>\n',

--- a/src/graphql/__mocks__/mockTypeDefs.graphql
+++ b/src/graphql/__mocks__/mockTypeDefs.graphql
@@ -21,32 +21,37 @@ input Pagination {
   limit: Int
 }
 
-input FieldMatch {
-  name: String!
-  value: String!
-}
-
-input FieldMatcher {
-  fields: [FieldMatch!]!
-}
-
-input ContentItemsQuery {
-  ids: [ID!]
-  groupIds: [ID!]
-  fieldMatcher: FieldMatcher
-}
-
-type ContentItem {
-  id: ID!
-  groupId: ID!
+input Fields {
+  id: ID
+  groupId: ID
   html: String
+  # field defs below will have been dynamically injected by pkg
   test: String
   order: Int
   temperature: Float
   isContentItem: Boolean
 }
 
+type ContentItem {
+  id: ID!
+  groupId: ID!
+  html: String
+  # field defs below will have been dynamically injected by pkg
+  test: String
+  order: Int
+  temperature: Float
+  isContentItem: Boolean
+}
+
+input FilterFields {
+  AND: Fields
+  OR: [Fields!]
+}
+
 type Query {
-  contentItem(id: ID!): ContentItem
-  contentItems(query: ContentItemsQuery!, pagination: Pagination): [ContentItem!]
+  contentItemById(id: ID!): ContentItem
+  contentItemsByIds(ids: [ID!]!, pagination: Pagination): [ContentItem!]
+  contentItemsByGroupId(groupId: ID!, pagination: Pagination): [ContentItem!]
+  # Query for contentItems by any field
+  contentItems(filter: FilterFields!, pagination: Pagination): [ContentItem!]
 }

--- a/src/graphql/queryHelpers.js
+++ b/src/graphql/queryHelpers.js
@@ -1,18 +1,12 @@
-import {
-  convertOrderBy,
-  metaDataToObject,
-  isMultiArgsQuery,
-  mapContentItems,
-} from '../helpers';
-
 import { find, findOne, dataStore } from '../database';
+import { convertOrderBy, mapContentItems } from '../helpers';
 
 /**
  * Retrieves the specified ContentItem by it's id.
  * @param {string} id - The id of the ContentItem
  * @returns {Object|null} returns the ContentItem or null on error.
  */
-export const getContentItem = async id => {
+export const findContentItemById = async id => {
   // Don't even bother if we didn't get an ID
   if (id) {
     try {
@@ -30,8 +24,82 @@ export const getContentItem = async id => {
   return null;
 };
 
+// *********************** TODO ********************
+// TODO: Refactor and abstract all three functions try/catch block code into
+// a single function that will query the nedb for us.
+// e.g queryDB({ query, sort, skip, limit, errorMsg });
+export const findContentItemsByIds = async ({
+  ids = [],
+  pagination: { sort = null, skip = 0, limit = 0 } = {},
+}) => {
+  // We do not allow returning every ContentItem
+  if (!ids.length) {
+    throw new Error(
+      '[findContentItemsByIds]: You must provide at least one id.',
+    );
+  }
+
+  try {
+    const query = { id: { $in: ids } };
+
+    const sortOptions = sort
+      ? { [sort.sortBy]: convertOrderBy(sort.orderBy) }
+      : null;
+
+    const contentItems = await find({
+      db: dataStore,
+      query,
+      sortOptions,
+      skip,
+      limit,
+      mapFunc: mapContentItems,
+    });
+
+    return contentItems;
+  } catch (error) {
+    // TODO: Should we throw or only log?
+    console.error('[getContentItemsByIds] -> ', error); // eslint-disable-line no-console
+  }
+  // NOTE: Should we do a throw in the error above instead of empty array?
+  return [];
+};
+
+export const findContentItemsByGroupId = async ({
+  groupId,
+  pagination: { sort = null, skip = 0, limit = 0 } = {},
+}) => {
+  // We do not allow returning every ContentItem
+  if (!groupId) {
+    throw new Error('[findByGroupId]: You must provide a groupId.');
+  }
+  try {
+    const query = { groupId };
+
+    const sortOptions = sort
+      ? { [sort.sortBy]: convertOrderBy(sort.orderBy) }
+      : null;
+
+    const contentItems = await find({
+      db: dataStore,
+      query,
+      sortOptions,
+      skip,
+      limit,
+      mapFunc: mapContentItems,
+    });
+
+    return contentItems;
+  } catch (error) {
+    // TODO: Should we throw or only log?
+    console.error('[getContentItemsByGroupId] -> ', error); // eslint-disable-line no-console
+  }
+  // NOTE: Should we do a throw in the error above instead of empty array?
+  return [];
+};
+
+// contentItems(filter: FilterFields!, pagination: Pagination): [ContentItem!]
 /**
- * Creates an object that maps the local fullPath of an image to it's desired path. e.g - { fullPathName: "cdn.com/foo.png", ... }
+ *
  * @param {Object} param
  * @param {string[]} param.ids - ContentItem's ids
  * @param {string[]} param.groupIds - ContentItem's groupIds
@@ -39,54 +107,42 @@ export const getContentItem = async id => {
  * @param {Object} param.pagination - Refer to Pagination in `src/graphql/typeDefs.graphql`
  * @returns {Object[]} returns an array of ContentItems.
  */
-export const getContentItems = async ({
-  ids = [],
-  groupIds = [],
-  fieldMatcher: { fields = [] } = {},
+// getContentItems(ids: [foo, boo])
+// getContentItemsByField(fields: { title: "Hello World" });
+
+export const findContentItemsByFilter = async ({
+  filter: { AND = {}, OR = [] } = {},
   pagination: { sort = null, skip = 0, limit = 0 } = {},
 }) => {
-  // NOTE: should we fail on passing an empty array?
-  if (!groupIds.length && !ids.length && !fields.length) {
+  // NOTE: Currently do no support querying with AND + OR
+  // TODO: Throw error if try to filter with AND & OR
+  const isAndEmpty = !Object.keys(AND).length;
+
+  // Only allowed to find ContentItems if fields have been provided
+  if (!OR.length && isAndEmpty) {
     throw new Error(
-      '[getContentItems]: Query expects at least one param, either ids, groupIds, or fieldMatcher.',
+      '[findContentItemsByFilter]: You must provide at least one field to filter on.',
     );
   }
-  // Don't even bother if we didn't get an ID
-  if (groupIds.length || ids.length || fields.length) {
-    try {
-      const idsQuery = { id: { $in: ids } };
-      const groupIdQuery = { groupId: { $in: groupIds } };
-      // TODO: Refactor to convert from string to correct type for the field
-      // or we need to modify the behaviour of fieldMatcher.
-      const fieldsQuery = metaDataToObject(fields);
 
-      const multiArgsQuery = { $or: [idsQuery, groupIdQuery, fieldsQuery] };
-      const singleArgQuery = {
-        ...(ids.length ? idsQuery : null),
-        ...(groupIds.length ? groupIdQuery : null),
-        ...(fields.length ? fieldsQuery : null),
-      };
+  try {
+    const query = !isAndEmpty ? AND : { $or: OR };
 
-      const query = isMultiArgsQuery({ ids, groupIds, fields })
-        ? multiArgsQuery
-        : singleArgQuery;
+    const sortOptions = sort
+      ? { [sort.sortBy]: convertOrderBy(sort.orderBy) }
+      : null;
 
-      const sortOptions = sort
-        ? { [sort.sortBy]: convertOrderBy(sort.orderBy) }
-        : null;
-
-      const contentItems = await find({
-        db: dataStore,
-        query,
-        sortOptions,
-        skip,
-        limit,
-        mapFunc: mapContentItems,
-      });
-      return contentItems;
-    } catch (error) {
-      console.error('[getContentItems]', error); // eslint-disable-line no-console
-    }
+    const contentItems = await find({
+      db: dataStore,
+      query,
+      sortOptions,
+      skip,
+      limit,
+      mapFunc: mapContentItems,
+    });
+    return contentItems;
+  } catch (error) {
+    console.error('[getContentItems] -> ', error); // eslint-disable-line no-console
   }
   return [];
 };

--- a/src/graphql/queryHelpers.test.js
+++ b/src/graphql/queryHelpers.test.js
@@ -1,26 +1,36 @@
 import { dataStore, insert } from '../database';
-import { getContentItem, getContentItems } from './queryHelpers';
+import {
+  findContentItemById,
+  findContentItemsByIds,
+  findContentItemsByGroupId,
+  findContentItemsByFilter,
+} from './queryHelpers';
 
+// ********* TODO ***********
+// Refactor try/catch block usage as it gives a false/positive result when it should fail.
 import {
   CONTENT_ITEM_1,
   CONTENT_ITEM_2,
+  CONTENT_ITEM_3,
   EXPECTED_RESULT_1,
   EXPECTED_RESULT_2,
+  EXPECTED_RESULT_3,
 } from './__mocks__/mockDbData';
 
 beforeAll(async () => {
   await insert({ db: dataStore, docToInsert: CONTENT_ITEM_1 });
   await insert({ db: dataStore, docToInsert: CONTENT_ITEM_2 });
+  await insert({ db: dataStore, docToInsert: CONTENT_ITEM_3 });
 });
 
 // TODO: Wrap getContentItem in describes & add more tests
-test('getContentItem', async () => {
+test('findContentItemById', async () => {
   expect.assertions(1);
   try {
-    const contentItem = await getContentItem('home_section');
+    const contentItem = await findContentItemById('home_section');
     expect(contentItem).toEqual(EXPECTED_RESULT_1);
   } catch (error) {
-    console.error('Error', error);
+    console.error('[Find by id]: ', error);
   }
 });
 
@@ -29,74 +39,103 @@ test('getContentItems by ids', async () => {
   expect.assertions(2);
   try {
     // Test returning a single contentItem
-    const singleContentItem = await getContentItems({ ids: ['home_section'] });
+    const singleContentItem = await findContentItemsByIds({
+      ids: ['home_section'],
+    });
     expect(singleContentItem).toEqual([EXPECTED_RESULT_1]);
 
     // Test returning multiple contentItems
-    const multiContentItem = await getContentItems({
+    const multiContentItem = await findContentItemsByIds({
       ids: ['home_section', 'main_section'],
     });
     expect(multiContentItem).toEqual([EXPECTED_RESULT_1, EXPECTED_RESULT_2]);
   } catch (error) {
-    console.error('Error', error);
+    console.error('[Find by ids]: ', error);
   }
 });
 
-test('getContentItems by groupIds', async () => {
+test('Search for ContentItems by groupIds, it returns the expected ContentItems.', async () => {
   expect.assertions(1);
   try {
     // Test returning all contentItems with specific groupId
-    const contentItems = await getContentItems({
-      groupIds: ['contentItems_test'],
+    const contentItems = await findContentItemsByGroupId({
+      groupId: 'contentItems_test',
     });
     expect(contentItems).toEqual([EXPECTED_RESULT_1, EXPECTED_RESULT_2]);
   } catch (error) {
-    console.error('Error', error);
+    console.error('[Find by groupIds]: ', error);
   }
 });
 
-test('getContentItems by fieldMatcher', async () => {
+test('Filtering by AND, it returns ContentItems matching all conditions.', async () => {
   expect.assertions(1);
   try {
     // Test returning contentItems by specific fields
-    const contentItems = await getContentItems({
-      fieldMatcher: {
-        fields: [{ name: 'groupId', value: 'contentItems_test' }],
+    const contentItems = await findContentItemsByFilter({
+      filter: {
+        AND: { groupId: 'contentItems_test', temperature: 30.5 },
       },
     });
-    expect(contentItems).toEqual([EXPECTED_RESULT_1, EXPECTED_RESULT_2]);
+    expect(contentItems).toEqual([EXPECTED_RESULT_2]);
+    // TODO: Test OR condition/query
   } catch (error) {
-    console.error('Error', error);
+    console.error('[Find by filter - AND]: ', error);
   }
 });
 
-test('getContentItems with pagination', async () => {
+test('Filtering by OR, it returns ContentItems matching all conditions.', async () => {
+  expect.assertions(1);
+  try {
+    // Test returning contentItems by specific fields
+    const contentItems = await findContentItemsByFilter({
+      filter: {
+        OR: [
+          { groupId: 'contentItems_test', temperature: 30.5 },
+          { temperature: 345.5 },
+        ],
+      },
+    });
+    expect(contentItems).toEqual([EXPECTED_RESULT_2, EXPECTED_RESULT_3]);
+  } catch (error) {
+    console.error('[Find by filter - OR]: ', error);
+  }
+});
+
+test('Search for ContentItems by filter and pagination.', async () => {
   expect.assertions(3);
   try {
     // Test returning contentItems in reverse order via sort
-    const sortTest = await getContentItems({
-      groupIds: ['contentItems_test'],
+    const sortTest = await findContentItemsByIds({
+      ids: ['main_section', 'home_section', 'fire_man'],
       pagination: { sort: { sortBy: 'order', orderBy: 'DESCENDING' } },
     });
-    expect(sortTest).toEqual([EXPECTED_RESULT_2, EXPECTED_RESULT_1]);
+
+    expect(sortTest).toEqual([
+      EXPECTED_RESULT_3,
+      EXPECTED_RESULT_2,
+      EXPECTED_RESULT_1,
+    ]);
 
     // Test returning contentItems in reverse order and the skipping first result
-    const skipTest = await getContentItems({
-      groupIds: ['contentItems_test'],
+    const skipTest = await findContentItemsByGroupId({
+      groupId: 'contentItems_test',
       pagination: { sort: { sortBy: 'order', orderBy: 'DESCENDING' }, skip: 1 },
     });
+
     expect(skipTest).toEqual([EXPECTED_RESULT_1]);
 
     // Test returning contentItems in reverse order and limiting to one result
-    const limitTest = await getContentItems({
-      groupIds: ['contentItems_test'],
+    const limitTest = await findContentItemsByFilter({
+      filter: {
+        OR: [{ groupId: 'contentItems_test' }, { groupId: 'fireman_test' }],
+      },
       pagination: {
         sort: { sortBy: 'order', orderBy: 'DESCENDING' },
         limit: 1,
       },
     });
-    expect(limitTest).toEqual([EXPECTED_RESULT_2]);
+    expect(limitTest).toEqual([EXPECTED_RESULT_3]);
   } catch (error) {
-    console.error('Error', error);
+    console.error('[Pagination]: ', error);
   }
 });

--- a/src/graphql/resolvers.js
+++ b/src/graphql/resolvers.js
@@ -1,10 +1,17 @@
 import * as queryHelpers from './queryHelpers';
 
 const Query = {
-  contentItem: async (root, { id } /* , context */) =>
-    queryHelpers.getContentItem(id),
-  contentItems: async (root, { query, pagination } /* , context */) =>
-    queryHelpers.getContentItems({ ...query, pagination }),
+  contentItemById: async (root, { id } /* , context */) =>
+    queryHelpers.findContentItemById(id),
+
+  contentItemsByIds: async (root, { ids, pagination } /* , context */) =>
+    queryHelpers.findContentItemsByIds({ ids, pagination }),
+
+  contentItemsByGroupId: async (root, { groupId, pagination } /* , ctx */) =>
+    queryHelpers.findContentItemsByGroupId({ groupId, pagination }),
+
+  contentItems: async (root, { filter, pagination } /* , context */) =>
+    queryHelpers.findContentItemsByFilter({ filter, pagination }),
 };
 
 export default { Query };

--- a/src/graphql/resolvers.test.js
+++ b/src/graphql/resolvers.test.js
@@ -27,7 +27,7 @@ describe('contentItem Resolver', () => {
     test('finds the expected ContentItem', async () => {
       expect.assertions(1);
       const query = `{
-        contentItem(id: "home_section") {
+        contentItemById(id: "home_section") {
           id
           groupId
           html
@@ -35,7 +35,9 @@ describe('contentItem Resolver', () => {
       }`;
       const result = await graphql(schema, query);
       const { id, groupId, html } = EXPECTED_RESULT_1;
-      expect(result).toEqual({ data: { contentItem: { id, groupId, html } } });
+      expect(result).toEqual({
+        data: { contentItemById: { id, groupId, html } },
+      });
     });
   });
 
@@ -43,14 +45,14 @@ describe('contentItem Resolver', () => {
     test('returns null', async () => {
       expect.assertions(1);
       const query = `{
-        contentItem(id: "i_dont_exist") {
+        contentItemById(id: "i_dont_exist") {
           id
           groupId
           html
         }
       }`;
       const result = await graphql(schema, query);
-      expect(result).toEqual({ data: { contentItem: null } });
+      expect(result).toEqual({ data: { contentItemById: null } });
     });
   });
 });
@@ -62,7 +64,7 @@ describe('contentItems Resolver', () => {
         expect.assertions(1);
 
         const singleIdQuery = `{
-          contentItems(query: { ids: ["home_section"] }) {
+          contentItemsByIds(ids: ["home_section"],) {
             id
             groupId
           }
@@ -71,7 +73,7 @@ describe('contentItems Resolver', () => {
         const contentItems = await graphql(schema, singleIdQuery);
         expect(contentItems).toEqual({
           data: {
-            contentItems: [
+            contentItemsByIds: [
               { id: 'home_section', groupId: 'contentItems_test' },
             ],
           },
@@ -82,7 +84,7 @@ describe('contentItems Resolver', () => {
         expect.assertions(1);
 
         const multiIdQuery = `{
-          contentItems(query: { ids: ["home_section", "main_section"] }) {
+          contentItemsByIds(ids: ["home_section", "main_section"]) {
             id
             groupId
           }
@@ -91,7 +93,7 @@ describe('contentItems Resolver', () => {
         const contentItems = await graphql(schema, multiIdQuery);
         expect(contentItems).toEqual({
           data: {
-            contentItems: [
+            contentItemsByIds: [
               { id: 'home_section', groupId: 'contentItems_test' },
               { id: 'main_section', groupId: 'contentItems_test' },
             ],
@@ -103,8 +105,8 @@ describe('contentItems Resolver', () => {
         expect.assertions(1);
 
         const sortQuery = `{
-          contentItems(
-            query: { ids: ["home_section", "main_section"] },
+          contentItemsByIds(
+            ids: ["home_section", "main_section"],
             pagination: {
               sort: {
                 sortBy: "order",
@@ -122,7 +124,7 @@ describe('contentItems Resolver', () => {
         const contentItems = await graphql(schema, sortQuery);
         expect(contentItems).toEqual({
           data: {
-            contentItems: [
+            contentItemsByIds: [
               { id: 'main_section', order: 2 },
               { id: 'home_section', order: 1 },
             ],
@@ -134,8 +136,8 @@ describe('contentItems Resolver', () => {
         expect.assertions(1);
 
         const sortedLimitQuery = `{
-          contentItems(
-            query: { ids: ["home_section", "main_section"] },
+          contentItemsByIds(
+            ids: ["home_section", "main_section"],
             pagination: {
               sort: {
                 sortBy: "order",
@@ -152,7 +154,7 @@ describe('contentItems Resolver', () => {
         const contentItems = await graphql(schema, sortedLimitQuery);
         expect(contentItems).toEqual({
           data: {
-            contentItems: [{ id: 'main_section', order: 2 }],
+            contentItemsByIds: [{ id: 'main_section', order: 2 }],
           },
         });
       });
@@ -161,8 +163,8 @@ describe('contentItems Resolver', () => {
         expect.assertions(1);
 
         const sortedSkipQuery = `{
-          contentItems(
-            query: { ids: ["home_section", "main_section"] },
+          contentItemsByIds(
+            ids: ["home_section", "main_section"],
             pagination: {
               sort: {
                 sortBy: "order",
@@ -179,7 +181,7 @@ describe('contentItems Resolver', () => {
         const contentItems = await graphql(schema, sortedSkipQuery);
         expect(contentItems).toEqual({
           data: {
-            contentItems: [{ id: 'home_section', order: 1 }],
+            contentItemsByIds: [{ id: 'home_section', order: 1 }],
           },
         });
       });
@@ -188,8 +190,8 @@ describe('contentItems Resolver', () => {
         expect.assertions(1);
 
         const skipQuery = `{
-          contentItems(
-            query: { ids: ["home_section", "main_section"] },
+          contentItemsByIds(
+            ids: ["home_section", "main_section"],
             pagination: {
               skip: 5,
             })
@@ -202,7 +204,7 @@ describe('contentItems Resolver', () => {
         const contentItems = await graphql(schema, skipQuery);
         expect(contentItems).toEqual({
           data: {
-            contentItems: [],
+            contentItemsByIds: [],
           },
         });
       });
@@ -213,7 +215,7 @@ describe('contentItems Resolver', () => {
         expect.assertions(1);
 
         const singleIdQuery = `{
-          contentItems(query: { groupIds: ["contentItems_test"] }) {
+          contentItems(filter: { AND: { groupId: "contentItems_test" } }) {
             id
             groupId
           }
@@ -234,7 +236,13 @@ describe('contentItems Resolver', () => {
         expect.assertions(1);
 
         const multiIdQuery = `{
-          contentItems(query: { groupIds: ["contentItems_test", "fireman_test"] }) {
+          contentItems(filter: {
+            OR: [
+              { groupId: "contentItems_test" },
+              { groupId: "fireman_test" }
+            ]
+          })
+          {
             id
             groupId
           }
@@ -257,7 +265,12 @@ describe('contentItems Resolver', () => {
 
         const sortQuery = `{
           contentItems(
-            query: { groupIds: ["contentItems_test", "fireman_test"] },
+            filter: {
+              OR: [
+                { groupId: "contentItems_test" },
+                { groupId: "fireman_test" }
+              ]
+            },
             pagination: {
               sort: {
                 sortBy: "order",
@@ -289,7 +302,12 @@ describe('contentItems Resolver', () => {
 
         const sortedLimitQuery = `{
           contentItems(
-            query: { groupIds: ["contentItems_test", "fireman_test"] },
+            filter: {
+              OR: [
+                { groupId: "contentItems_test" },
+                { groupId: "fireman_test" }
+              ]
+            },
             pagination: {
               sort: {
                 sortBy: "order",
@@ -316,7 +334,12 @@ describe('contentItems Resolver', () => {
 
         const sortedSkipQuery = `{
           contentItems(
-            query: { groupIds: ["contentItems_test", "fireman_test"] },
+            filter: {
+              OR: [
+                { groupId: "contentItems_test" },
+                { groupId: "fireman_test" }
+              ]
+            },
             pagination: {
               sort: {
                 sortBy: "order",
@@ -346,7 +369,12 @@ describe('contentItems Resolver', () => {
 
         const skipQuery = `{
           contentItems(
-            query: { groupIds: ["contentItems_test", "fireman_test"] },
+            filter: {
+              OR: [
+                { groupId: "contentItems_test" },
+                { groupId: "fireman_test" }
+              ]
+            },
             pagination: {
               skip: 5,
             })
@@ -365,22 +393,203 @@ describe('contentItems Resolver', () => {
       });
     });
 
-    // TODO: Replace queries with groupId with another field once the fieldMatcher
-    // fieldsQuery has been refactored to allow `value` to be any scalar type.
-    // API for fieldMatcher will need to be rethought to enable queries by types other then a String.
-    describe('And searching with fieldMatcher', () => {
-      // TODO: Add below Tests once the fieldMatcher query has been refactored.
-      // - Add tests to cover all scalar types we allow.
-      // - Add test where we mix a query with differing types
-      // Float, Int, String, Boolean
-      test('With a single field, it returns contentItems matching the field queried.', async () => {
+    describe('And searching by filter', () => {
+      test('With a single field, it returns contentItems that contain the field queried by.', async () => {
+        expect.assertions(1);
+
+        const singleIdQuery = `{
+          contentItems(filter: { AND: { groupId: "contentItems_test" } }) {
+            id
+            groupId
+          }
+        }`;
+
+        const contentItems = await graphql(schema, singleIdQuery);
+        expect(contentItems).toEqual({
+          data: {
+            contentItems: [
+              { id: 'home_section', groupId: 'contentItems_test' },
+              { id: 'main_section', groupId: 'contentItems_test' },
+            ],
+          },
+        });
+      });
+
+      // TODO: We should think about merging the AND & OR tests together and do
+      // multiple asserts. Need to structure this more cleanly.
+      // NOTE: TESTING -> filter: OR usage below.
+      // , it returns contentItems that contain the fields specified.
+      test('[Filter] OR - With multiple fields of the same type', async () => {
+        expect.assertions(1);
+
+        const multiIdQuery = `{
+          contentItems(filter: {
+            OR: [
+              { groupId: "contentItems_test" },
+              { groupId: "fireman_test" }
+            ]
+          })
+          {
+            id
+            groupId
+          }
+        }`;
+
+        const contentItems = await graphql(schema, multiIdQuery);
+        expect(contentItems).toEqual({
+          data: {
+            contentItems: [
+              { id: 'home_section', groupId: 'contentItems_test' },
+              { id: 'main_section', groupId: 'contentItems_test' },
+              { id: 'fire_man', groupId: 'fireman_test' },
+            ],
+          },
+        });
+      });
+
+      test('[Filter] OR - Sorted in reverse order.', async () => {
+        expect.assertions(1);
+
+        const sortQuery = `{
+          contentItems(
+            filter: {
+              OR: [
+                { groupId: "contentItems_test" },
+                { order: 3, temperature: 345.5 }
+              ]
+            },
+            pagination: {
+              sort: {
+                sortBy: "order",
+                orderBy: DESCENDING
+              },
+              skip: 0,
+              limit: 0
+            })
+          {
+            id
+            order
+          }
+        }`;
+
+        const contentItems = await graphql(schema, sortQuery);
+        expect(contentItems).toEqual({
+          data: {
+            contentItems: [
+              { id: 'fire_man', order: 3 },
+              { id: 'main_section', order: 2 },
+              { id: 'home_section', order: 1 },
+            ],
+          },
+        });
+      });
+
+      test('[Filter] OR - Limit result to 1 contentItem sorted in reverse order', async () => {
+        expect.assertions(1);
+
+        const sortedLimitQuery = `{
+          contentItems(
+            filter: {
+              OR: [
+                { groupId: "contentItems_test" },
+                { temperature: 345.5 }
+              ]
+            },
+            pagination: {
+              sort: {
+                sortBy: "order",
+                orderBy: DESCENDING
+              },
+              limit: 1
+            })
+          {
+            id
+            order
+          }
+        }`;
+
+        const contentItems = await graphql(schema, sortedLimitQuery);
+        expect(contentItems).toEqual({
+          data: {
+            contentItems: [{ id: 'fire_man', order: 3 }],
+          },
+        });
+      });
+
+      test('[Filter] OR - Skip the first item whilst sorted in reverse order.', async () => {
+        expect.assertions(1);
+
+        const sortedSkipQuery = `{
+          contentItems(
+            filter: {
+              OR: [
+                { groupId: "contentItems_test" },
+                { temperature: 345.5 }
+              ]
+            },
+            pagination: {
+              sort: {
+                sortBy: "order",
+                orderBy: DESCENDING
+              },
+              skip: 1,
+            })
+          {
+            id
+            order
+          }
+        }`;
+
+        const contentItems = await graphql(schema, sortedSkipQuery);
+        expect(contentItems).toEqual({
+          data: {
+            contentItems: [
+              { id: 'main_section', order: 2 },
+              { id: 'home_section', order: 1 },
+            ],
+          },
+        });
+      });
+
+      test('[Filter] OR - Skip all items, it returns an empty array.', async () => {
+        expect.assertions(1);
+
+        const skipQuery = `{
+          contentItems(
+            filter: {
+              OR: [
+                { groupId: "contentItems_test" },
+                { groupId: "fireman_test" }
+              ]
+            },
+            pagination: {
+              skip: 5,
+            })
+          {
+            id
+            order
+          }
+        }`;
+
+        const contentItems = await graphql(schema, skipQuery);
+        expect(contentItems).toEqual({
+          data: {
+            contentItems: [],
+          },
+        });
+      });
+
+      // TODO: Think about merging the tests for AND & OR under same tests.
+      // e.g - make each test do 2 or more asserts?
+      // NOTE: TESTING -> filter: AND usage below.
+      test('[Filter] AND - With a single field, it returns contentItems matching the field queried.', async () => {
         expect.assertions(1);
 
         const singleIdQuery = `{
           contentItems(
-            query: {
-              fieldMatcher: {
-                fields: [{ name: "test", value: "I am a ContentItem!" }]
+            filter: {
+              AND: {
+                 test: "I am a ContentItem!"
               }
             })
           {
@@ -397,17 +606,15 @@ describe('contentItems Resolver', () => {
         });
       });
 
-      test('With multi fields, it returns only the contentItems that match all the fields queried by.', async () => {
+      test('[Filter] AND - With multiple fields, it returns only the contentItems that match all fields specified.', async () => {
         expect.assertions(1);
 
         const multiIdQuery = `{
           contentItems(
-            query: {
-              fieldMatcher: {
-                fields: [
-                  { name: "test", value: "I am a ContentItem!" },
-                  { name: "groupId", value: "contentItems_test" },
-                ]
+            filter: {
+              AND: {
+                test: "I am a ContentItem!",
+                groupId: "contentItems_test"
               }
             })
           {
@@ -431,14 +638,14 @@ describe('contentItems Resolver', () => {
         });
       });
 
-      test('Sorted in reverse order, it returns contentItems in reverse order.', async () => {
+      test('[Filter] AND - Sorted in reverse order, it returns contentItems in reverse order.', async () => {
         expect.assertions(1);
 
         const sortQuery = `{
           contentItems(
-            query: {
-              fieldMatcher: {
-                fields: [{ name: "groupId", value: "contentItems_test" }]
+            filter: {
+              AND: {
+                 groupId: "contentItems_test"
               }
             },
             pagination: {
@@ -467,14 +674,14 @@ describe('contentItems Resolver', () => {
         });
       });
 
-      test('Limit result to 1 contentItem sorted in reverse order, it returns the first contentItem', async () => {
+      test('[Filter] AND - Limit result to 1 contentItem sorted in reverse order, it returns the first contentItem', async () => {
         expect.assertions(1);
 
         const sortedLimitQuery = `{
           contentItems(
-            query: {
-              fieldMatcher: {
-                fields: [{ name: "groupId", value: "contentItems_test" }]
+            filter: {
+              AND: {
+                 groupId: "contentItems_test"
               }
             },
             pagination: {
@@ -501,14 +708,14 @@ describe('contentItems Resolver', () => {
         });
       });
 
-      test('Skip the first item whilst sorted in reverse order, it returns contentItems without the skipped item.', async () => {
+      test('[Filter] AND - Skip the first item whilst sorted in reverse order.', async () => {
         expect.assertions(1);
 
         const sortedSkipQuery = `{
           contentItems(
-            query: {
-              fieldMatcher: {
-                fields: [{ name: "groupId", value: "contentItems_test" }]
+            filter: {
+              AND: {
+                 groupId: "contentItems_test"
               }
             },
             pagination: {
@@ -535,14 +742,14 @@ describe('contentItems Resolver', () => {
         });
       });
 
-      test('Skip all items, it returns an empty array.', async () => {
+      test('[Filter] AND - Skip all items, it returns an empty array.', async () => {
         expect.assertions(1);
 
         const skipQuery = `{
           contentItems(
-            query: {
-              fieldMatcher: {
-                fields: [{ name: "groupId", value: "contentItems_test" }]
+            filter: {
+              AND: {
+                 groupId: "contentItems_test"
               }
             },
             pagination: {
@@ -570,7 +777,7 @@ describe('contentItems Resolver', () => {
       expect.assertions(1);
 
       const idsQuery = `{
-          contentItems(query: { ids: ["i_dont_exist", "i_dont_exist2"] })
+          contentItemsByIds(ids: ["i_dont_exist", "i_dont_exist2"] )
           {
             id
             order
@@ -580,7 +787,7 @@ describe('contentItems Resolver', () => {
       const contentItems = await graphql(schema, idsQuery);
       expect(contentItems).toEqual({
         data: {
-          contentItems: [],
+          contentItemsByIds: [],
         },
       });
     });
@@ -589,7 +796,7 @@ describe('contentItems Resolver', () => {
       expect.assertions(1);
 
       const groupIdsQuery = `{
-          contentItems(query: { groupIds: ["i_dont_exist"] })
+          contentItemsByGroupId(groupId: "i_dont_exist")
           {
             id
             groupId,
@@ -600,17 +807,17 @@ describe('contentItems Resolver', () => {
       const contentItems = await graphql(schema, groupIdsQuery);
       expect(contentItems).toEqual({
         data: {
-          contentItems: [],
+          contentItemsByGroupId: [],
         },
       });
     });
 
-    test('And searching by fieldMatcher, it returns an empty array.', async () => {
+    test('And searching by filter, it returns an empty array.', async () => {
       expect.assertions(1);
 
       const fieldMatcherQuery = `{
-          contentItems(query: {
-            fieldMatcher: { fields: [{ name: "temperature", value: 5.0 }] }
+          contentItems(filter: {
+            AND: { temperature: 5.0 }
           })
           {
             id

--- a/src/graphql/typeDefs.graphql
+++ b/src/graphql/typeDefs.graphql
@@ -21,28 +21,35 @@ input Pagination {
   limit: Int
 }
 
-input FieldMatch {
-  name: String!
-  value: String!
-}
-
-input FieldMatcher {
-  fields: [FieldMatch!]!
-}
-
-input ContentItemsQuery {
-  ids: [ID!]
-  groupIds: [ID!]
-  fieldMatcher: FieldMatcher
+input Fields {
+  id: ID
+  groupId: ID
+  html: String
+  # field defs generated from .md front-matter will be injected by pkg here.
 }
 
 type ContentItem {
+  # Mandatory - a unique id must exist for every .md file.
   id: ID!
+  # Mandatory - a non unique groupId must exist for every .md file. If you do not
+  # wish to manually set you can use the generateGroupIdByFolder option check pkg Readme.
   groupId: ID!
+  # The html generated from parsing the .md contents.
   html: String
+  # field defs generated from .md front-matter will be injected by pkg here.
+}
+
+input FilterFields {
+  # Query ContentItems by any fields using logical AND condition.
+  AND: Fields
+  # Query ContentItems by any fields using logical OR condition.
+  OR: [Fields!]
 }
 
 type Query {
-  contentItem(id: ID!): ContentItem
-  contentItems(query: ContentItemsQuery!, pagination: Pagination): [ContentItem!]
+  contentItemById(id: ID!): ContentItem
+  contentItemsByIds(ids: [ID!]!, pagination: Pagination): [ContentItem!]
+  contentItemsByGroupId(groupId: ID!, pagination: Pagination): [ContentItem!]
+  # Query for contentItems by any field
+  contentItems(filter: FilterFields!, pagination: Pagination): [ContentItem!]
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,24 +6,6 @@
 export const getRelativeFilename = fullPathName =>
   fullPathName.slice(fullPathName.lastIndexOf('/') + 1);
 
-/**
- * Convert metaData from it's Object format to an Array of Objects.
- * NOTE: We are using es7 Object.entries.
- * @param {Object} metaData - Extra key/value pairs from a .md file. e.g - { foo: "bar" }
- * @returns {Array} metaData matching the gql schema format. e.g - [{ name: "foo", value: "bar" }, ...]
- */
-export const metaDataToArray = metaData =>
-  Object.entries(metaData).map(([key, value]) => ({ name: key, value }));
-
-/**
- * Convert metaData from it's gql schema format to it's Object format
- * with "key": "value" pairs.
- * @param {Array} metaData - [{ name: "", value: "foo" }, ...]
- * @returns {Object} metaData formatted as an object with it's "key": "value" pairs.
- */
-export const metaDataToObject = metaData =>
-  metaData.reduce((sum, { name, value }) => ({ ...sum, [name]: value }), {});
-
 // TODO: Decide if we will keep the getGroupId function
 /**
  * Returns the groupId from the file's path.
@@ -60,22 +42,6 @@ export const convertOrderBy = orderBy => {
     return -1;
   }
   return 1;
-};
-
-/**
- * Determine if a query has mulitple arguments
- * @param {Object} args - object containing all args provided by the client.
- * @returns {boolean}
- */
-// prettier-ignore
-export const isMultiArgsQuery = args => {
-  const count = Object.entries(args).reduce((sum, [key, value]) => { // eslint-disable-line
-    if (value && value.length > 0) {
-      return sum + 1;
-    }
-    return sum;
-  }, 0);
-  return count > 1;
 };
 
 /**

--- a/src/markdown-content/getMarkdownObject.js
+++ b/src/markdown-content/getMarkdownObject.js
@@ -38,6 +38,7 @@ const getMarkdownObject = async ({
     ? replaceContents({ contentRoot, rawContents })
     : rawContents;
 
+  // TODO: Abstract the below matter processing into its own function
   // WARNING: The 4 variables below are mutated directly by gqlTypeListener()
   let currKey = ''; // eslint-disable-line
   const stack = [];
@@ -68,8 +69,10 @@ const getMarkdownObject = async ({
     imageFormats,
   );
 
-  // TODO: Deprecate this in future ?
-  // If we deprecate then we must state every .md file must provide a groupId!
+  // TODO: Setup logic for if generateGroupIdByFolder is true
+  // When true, we will enable defaultGroupId to be inferred from the folder the
+  // .md file is currently located within.
+  // When not turned on every .md file must set a groupId!
   const defaultGroupId = getGroupId(assetDir);
 
   const newHtml = replaceHtmlImageSrc({ images, imageMap, html });

--- a/src/markdown-content/index.js
+++ b/src/markdown-content/index.js
@@ -44,9 +44,9 @@ const loadMarkdownIntoDb = async ({
   );
 
   // Generate the packages TypeDefs to return to the pkg user
-  const { graphqlMarkdownTypeDefs } = createGraphqlMarkdownTypeDefs({
-    contentItemGqlFields,
-    contentItemTypeDefs,
+  const graphqlMarkdownTypeDefs = createGraphqlMarkdownTypeDefs({
+    originalTypeDefs: contentItemTypeDefs,
+    fieldDefsToAdd: contentItemGqlFields,
   });
 
   // Insert all ContentItems into the in-memory nedb instance.

--- a/src/markdown-content/loadContentItems.js
+++ b/src/markdown-content/loadContentItems.js
@@ -22,6 +22,8 @@ const loadContentItems = async ({
   replaceContents,
   debugMode = false,
   codeHighlighter,
+  // TODO: Setup generateGroupIdByFolder logic and Update readme/setOptions
+  generateGroupIdByFolder = false,
 }) => {
   const isFunction = codeHighlighter && typeof codeHighlighter === 'function';
 


### PR DESCRIPTION

Designed queries to provide a simple & concise way to search for ContentItems. 🔥 
We are now able to query on any scalar type. 🔥 

Please read the updated pkg Readme included in this PR for further details on usage and examples. 

**Changes Made:**
- Tests refactored and additional mocks created for designing new Query API.
- Updated the typeDefs.graphql for new Query API see below snippet.
- Readme updated for the pkg & simple example
- Code refactored to support the new Query API.

```graphql

input Fields {
  id: ID
  groupId: ID
  html: String
  # field defs generated from .md front-matter will be injected by pkg here.
}

input FilterFields {
  AND: Fields    # Query ContentItems by any fields using logical AND condition.
  OR: [Fields!]   # Query ContentItems by any fields using logical OR condition.
}

type Query {
  contentItemById(id: ID!): ContentItem
  contentItemsByIds(ids: [ID!]!, pagination: Pagination): [ContentItem!]
  contentItemsByGroupId(groupId: ID!, pagination: Pagination): [ContentItem!]
  # Query for contentItems by any field
  contentItems(filter: FilterFields!, pagination: Pagination): [ContentItem!]
}
```

